### PR TITLE
Kill workers when they don't exit.

### DIFF
--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -1,6 +1,7 @@
 
 var child_process = require('child_process')
   , join = require("path").join
+  , timeout = process.env.SERVER_TIMEOUT || 7000
   , runner = require('../runner')
   , wrapper = join(__dirname,"/../wrapper");
 
@@ -44,8 +45,17 @@ module.exports = function(path, dev, clust) {
         return function() {
           if(cluster.disconnecting) return;
           cluster.disconnecting = true;
+          // Give workers just a bit more time to die on their own
+          var killTimer = setTimeout(function() {
+            for (var id in cluster.workers) {
+              var worker = cluster.workers[id];
+              console.log("Killing server("+worker.id+") because it took longer than "+timeout+"ms to shutdown.");
+              worker.process.kill('SIGKILL');
+            }
+          }, timeout+300);
           cluster.disconnect(function(){
             console.log("Shutting down master");
+            clearTimeout(killTimer);
           });
         };
       };


### PR DESCRIPTION
Give the cluster workers SERVER_TIMEOUT+300 ms to exit, and then
SIGKILL them for failing to exit on their own. This helps when the
app has some kind of problem blocking its event loop.
