### PR TITLE
Added support for debugging with node-inspector.

### DIFF
--- a/bin/startup-start
+++ b/bin/startup-start
@@ -24,6 +24,7 @@ program
   .option('-d, --dev', 'run in development mode')
   .option('--debug', 'run the debugger')
   .option('--debug-brk', 'run the debugger with a break on start')
+  .option('--node-inspector', 'run node-debug to enable debugging in chrome dev tools')
   .option('--use-strict', 'use strict mode')
   // .option('-s, --shutdown <shutdown>', 'server shutdown timeout')
   // .option('-t, --timeout <timeout>', 'worker restart timeout')
@@ -107,6 +108,25 @@ if (program.debug || program.debugBrk) {
   if (strict) args.unshift(strict);
 
   var proc = spawn('node', args, { stdio: 'inherit', customFds: [0, 1, 2] });
+
+  return proc.on('close', function(code){
+    process.exit(code);
+  });
+}
+
+/**
+ * Run in debug mode using node-inspector
+ */
+if (program.nodeInspector) {
+  // setup the arguments
+  var args = [
+    runner,
+    path
+  ];
+
+  if (strict) args.unshift(strict);
+
+  var proc = spawn('node-debug', args, { stdio: 'inherit', customFds: [0, 1, 2] });
 
   return proc.on('close', function(code){
     process.exit(code);


### PR DESCRIPTION
I'm a WebDev on the core team at Family Search.  There are some devs here at Family Search who use code editors like Sublime Text that would like to use Chrome Dev Tools to debug their node apps when it's launched via foreman.  So I added support for node-inspector.
